### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,6 @@ provider (hypervisor).
 Of course, you can use this environment to develop and test other things like
 Java applications, but that's not the focus of this documentation.
 
-* [Motivation](/motivation/)
-* [Getting Started](/getting_started/)
-* [Test Ansible Roles](/test_ansible_roles/)
+* [Motivation](motivation/)
+* [Getting Started](getting_started/)
+* [Test Ansible Roles](test_ansible_roles/)


### PR DESCRIPTION
On the page: https://ansible-development.readthedocs.io/en/master/, the three links at the bottom of the page (Motivation; Getting Started; Test Ansible Roles) are broken.

This edit changes them from absolute to relative links, which I think should fix them when they are rendered in readthedocs.io.